### PR TITLE
Check for valid optical method in Interface

### DIFF
--- a/rayflare/structure.py
+++ b/rayflare/structure.py
@@ -76,9 +76,14 @@ class Interface:
         texture=None,
         prof_layers=None,
         coherent=True,
-        **kwargs
+        **kwargs,
     ):
         """Layer class constructor."""
+        valid_methods = ["RT_Fresnel", "RT_TMM", "RCWA", "TMM", "Mirror", "Lambertian"]
+        if method not in valid_methods:
+            raise ValueError(
+                f"Unknown method {method}. Please use one of the following: {valid_methods}."
+            )
         self.method = method
         self.__dict__.update(kwargs)
         self.layers = layers

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,11 +1,17 @@
 import numpy as np
 from pytest import raises
 
-def pol_error():
+
+def test_pol_error():
     from rayflare.rigorous_coupled_wave_analysis.rcwa import process_pol
 
     pol_test = ["s", "p", "u", (np.sqrt(2) / 2, np.sqrt(2) / 2)]
-    pol_output = [(1, 0), (0, 1), (np.sqrt(2) / 2, np.sqrt(2) / 2), (np.sqrt(2) / 2, np.sqrt(2) / 2)]
+    pol_output = [
+        (1, 0),
+        (0, 1),
+        (np.sqrt(2) / 2, np.sqrt(2) / 2),
+        (np.sqrt(2) / 2, np.sqrt(2) / 2),
+    ]
 
     for i1, pol in enumerate(pol_test):
         assert process_pol(pol) == pol_output[i1]
@@ -15,6 +21,9 @@ def pol_error():
         process_pol("invalid")
 
 
+def test_optical_method_error():
+    from rayflare.structure import Interface
 
-
-
+    # check error is raised for invalid method
+    with raises(ValueError):
+        bad_surface = Interface("Non_existent_method", layers=[], name="test")


### PR DESCRIPTION
- Added a check for valid optical method in `Interface`.
- Added a test in `tests/test_errors.py`

This addresses https://github.com/qpv-research-group/rayflare/issues/35, I think it is better to catch this early rather than deferring it when calling `process_structure`.

Thanks for this great package!